### PR TITLE
2 fixes for new functions

### DIFF
--- a/VTFLib/VTFFile.cpp
+++ b/VTFLib/VTFFile.cpp
@@ -1582,8 +1582,20 @@ bool CVTFFile::SetVersion(vlUInt major, vlUInt minor)
 {
 	if (major != 7 || minor < 1 || minor > 6)
 		return false;
+
+	bool didSupportResources = GetSupportsResources();
+	
 	Header->Version[0] = major;
 	Header->Version[1] = minor;
+
+	bool doesSupportResources = GetSupportsResources();
+
+	// Add new resources for compatibility if we didn't previously
+	if (!didSupportResources && doesSupportResources) {
+		this->Header->Resources[this->Header->ResourceCount++].Type = VTF_LEGACY_RSRC_LOW_RES_IMAGE;
+		this->Header->Resources[this->Header->ResourceCount++].Type = VTF_LEGACY_RSRC_IMAGE;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
First, we are now using ComputeDataOffset in a more general sense for ConvertInPlace, but there is an assert that assumes that we are computing the data offset for the current file. This is not true in all cases (anymore), so I've moved the assert outside every call so that it appropriately uses the specific context of the call for the assert.

Second, SetVersion wasn't creating image resources in a conversion from <=7.2 to >7.2, leading to invalid saving when compressing old vtfs.

