### PR TITLE
Fix not specifying depth for ComputeImageSize in ConvertInPlace

### DIFF
--- a/VTFLib/VTFFile.cpp
+++ b/VTFLib/VTFFile.cpp
@@ -4121,7 +4121,7 @@ vlBool CVTFFile::ConvertInPlace(VTFImageFormat format)
 	const vlUInt uiSliceCount = GetDepth();
 
 	// Compute and allocate a working buffer- will replace lpImageData at the end
-	const vlUInt usBufferSize = this->ComputeImageSize(this->Header->Width, this->Header->Height, uiMipCount, format) * uiFrameCount * uiFaceCount;
+	const vlUInt usBufferSize = this->ComputeImageSize(this->Header->Width, this->Header->Height, uiSrcDepth, uiMipCount, format) * uiFrameCount * uiFaceCount;
 	auto* buffer = new vlByte[usBufferSize];
 
 	// Holy sweet mother of nested loops...


### PR DESCRIPTION
This leads to all sorts of wrong behavior involving the buffer size, because it's calculating it wrong!

Furthermore, since ImageFormat will always be RGBA8888, trying to convert to other formats leads to things like swapped color channels and other broken behavior.

One such issue caused by this: https://github.com/StrataSource/vtex2/issues/37